### PR TITLE
Redesign terminal as IBM 3151-style setup menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
     <div class="scanlines"></div>
     <div class="terminal-container">
         <div class="terminal-screen">
-            <div class="terminal-header">TYPEDCYPHER SYSTEMS</div>
             <div class="terminal-content">
                 <div id="terminal-output"></div>
                 <div class="cursor"></div>

--- a/script.js
+++ b/script.js
@@ -135,12 +135,12 @@ class AlienTerminal {
             tabEl.textContent = tab.label;
             tabEl.addEventListener('mouseenter', () => {
                 this.activeTab = index;
-                this.activeItem = 0;
+                this.activeItem = this.firstSelectableItem(this.tabs[index]);
                 this.renderMenu();
             });
             tabEl.addEventListener('click', () => {
                 this.activeTab = index;
-                this.activeItem = 0;
+                this.activeItem = this.firstSelectableItem(this.tabs[index]);
                 this.renderMenu();
             });
             tabBar.appendChild(tabEl);
@@ -183,27 +183,36 @@ class AlienTerminal {
         const currentTab = this.tabs[this.activeTab];
         if (!currentTab) return;
 
+        const hasSelectableItems = currentTab.items.some(item => item.link);
+
         currentTab.items.forEach((item, index) => {
             const row = document.createElement('div');
             row.className = 'setup-item';
-            if (index === this.activeItem) row.classList.add('setup-item-active');
-            if (item.link) row.classList.add('setup-item-link');
-            row.textContent = item.label;
+            if (item.link) {
+                row.classList.add('setup-item-link');
+                if (index === this.activeItem) row.classList.add('setup-item-active');
 
-            row.addEventListener('mouseenter', () => {
-                if (this.activeItem === index) return;
-                this.activeItem = index;
-                this.updateItemHighlight();
-            });
+                row.addEventListener('mouseenter', () => {
+                    if (this.activeItem === index) return;
+                    this.activeItem = index;
+                    this.updateItemHighlight();
+                });
 
-            row.addEventListener('click', () => {
-                if (item.link) {
+                row.addEventListener('click', () => {
                     window.open(item.link, '_blank', 'noopener,noreferrer');
-                }
-            });
+                });
+            } else {
+                row.classList.add('setup-item-static');
+            }
+            row.textContent = item.label;
 
             contentArea.appendChild(row);
         });
+    }
+
+    firstSelectableItem(tab) {
+        const index = tab.items.findIndex(item => item.link);
+        return index === -1 ? 0 : index;
     }
 
     updateItemHighlight() {
@@ -219,24 +228,30 @@ class AlienTerminal {
 
             const currentTab = this.tabs[this.activeTab];
 
+            const selectableIndices = currentTab.items
+                .map((item, i) => item.link ? i : -1)
+                .filter(i => i !== -1);
+
             if (e.key === 'l' || e.key === 'ArrowRight') {
                 e.preventDefault();
                 this.activeTab = (this.activeTab + 1) % this.tabs.length;
-                this.activeItem = 0;
+                this.activeItem = this.firstSelectableItem(this.tabs[this.activeTab]);
                 this.renderMenu();
             } else if (e.key === 'h' || e.key === 'ArrowLeft') {
                 e.preventDefault();
                 this.activeTab = (this.activeTab - 1 + this.tabs.length) % this.tabs.length;
-                this.activeItem = 0;
+                this.activeItem = this.firstSelectableItem(this.tabs[this.activeTab]);
                 this.renderMenu();
-            } else if (e.key === 'j' || e.key === 'ArrowDown') {
+            } else if ((e.key === 'j' || e.key === 'ArrowDown') && selectableIndices.length > 0) {
                 e.preventDefault();
-                this.activeItem = (this.activeItem + 1) % currentTab.items.length;
-                this.renderMenu();
-            } else if (e.key === 'k' || e.key === 'ArrowUp') {
+                const pos = selectableIndices.indexOf(this.activeItem);
+                this.activeItem = selectableIndices[(pos + 1) % selectableIndices.length];
+                this.updateItemHighlight();
+            } else if ((e.key === 'k' || e.key === 'ArrowUp') && selectableIndices.length > 0) {
                 e.preventDefault();
-                this.activeItem = (this.activeItem - 1 + currentTab.items.length) % currentTab.items.length;
-                this.renderMenu();
+                const pos = selectableIndices.indexOf(this.activeItem);
+                this.activeItem = selectableIndices[(pos - 1 + selectableIndices.length) % selectableIndices.length];
+                this.updateItemHighlight();
             } else if (e.key === 'Enter') {
                 e.preventDefault();
                 const item = currentTab.items[this.activeItem];

--- a/script.js
+++ b/script.js
@@ -1,12 +1,43 @@
-// Terminal typing effect with Alien-inspired boot sequence
+// IBM 3151-style setup menu terminal
 class AlienTerminal {
     constructor() {
         this.output = document.getElementById('terminal-output');
         this.cursor = document.querySelector('.cursor');
         this.typeSpeed = 50;
         this.lineDelay = 800;
-        this.menuOptions = [];
-        this.selectedIndex = -1;
+
+        this.tabs = [
+            {
+                label: 'GENERAL',
+                items: [
+                    { label: 'Welcome to typedCypher' },
+                    { label: 'Status: ONLINE' },
+                    { label: 'System: MOS 6502' },
+                    { label: 'Memory: 16384 KB' },
+                ]
+            },
+            {
+                label: 'INTERFACES',
+                items: [
+                    { label: 'GITHUB', link: 'https://github.com/typedcypher' },
+                    { label: 'X', link: 'https://x.com/typedcypher' },
+                    { label: 'NOSTR', link: 'https://njump.me/typedcypher.com' },
+                ]
+            },
+            {
+                label: 'PROJECTS',
+                items: [
+                    { label: 'historical-bitcoin-prices', link: 'https://github.com/typedcypher/historical-bitcoin-prices' },
+                    { label: 'mailveil-extension', link: 'https://github.com/typedcypher/mailveil-extension' },
+                    { label: 'nostr-vanity', link: 'https://github.com/typedcypher/nostr-vanity' },
+                ]
+            },
+        ];
+
+        this.activeTab = 0;
+        this.activeItem = 0;
+        this.menuReady = false;
+
         this.bootSequence();
     }
 
@@ -17,19 +48,18 @@ class AlienTerminal {
     async typeText(text, element = null, speed = this.typeSpeed) {
         const targetElement = element || this.output;
         const chars = text.split('');
-        
+
         for (const char of chars) {
             const span = document.createElement('span');
             span.textContent = char;
             span.className = 'char';
             span.style.animationDelay = '0s';
             targetElement.appendChild(span);
-            
-            // Move cursor after each character
+
             if (this.cursor && this.cursor.parentNode) {
                 targetElement.appendChild(this.cursor);
             }
-            
+
             await this.sleep(speed);
         }
     }
@@ -38,34 +68,25 @@ class AlienTerminal {
         const line = document.createElement('div');
         line.className = `terminal-line ${className}`;
         this.output.appendChild(line);
-        
-        // Trigger reflow to ensure animation plays
         line.offsetHeight;
-        
+
         if (typeEffect) {
             await this.typeText(text, line);
         } else {
             line.textContent = text;
             line.style.opacity = '1';
         }
-        
-        // Move cursor to end
+
         this.output.appendChild(this.cursor);
-        
         await this.sleep(this.lineDelay);
     }
 
     async bootSequence() {
-        // Initial boot delay
         await this.sleep(2000);
-        
-        // Create burn-in layers
-        this.createBurnInLayers();
-        
-        // System initialization
+
         await this.addLine('INITIALIZING SYSTEM...', '', true);
         await this.sleep(500);
-        
+
         await this.addLine('LOADING KERNEL MODULES...', '', false);
         await this.sleep(300);
         await this.addLine('[OK] MEMORY CHECK: 16384 KB', '', false);
@@ -74,208 +95,166 @@ class AlienTerminal {
         await this.sleep(200);
         await this.addLine('[OK] INTERFACE: ACTIVE', '', false);
         await this.sleep(500);
-        
+
         await this.addLine('', '', false);
         await this.addLine('ESTABLISHING CONNECTION...', '', true);
         await this.sleep(1000);
-        
-        // Clear screen effect
+
+        // Clear boot output and show setup menu
         this.output.innerHTML = '';
-        this.output.appendChild(this.cursor);
+        if (this.cursor) this.cursor.remove();
         await this.sleep(500);
-        
-        // Welcome message
-        await this.addLine('Welcome to typedCypher.', '', true);
-        await this.sleep(1000);
-        
-        await this.addLine('', '', false);
-        await this.addLine('SELECT INTERFACE:', '', true);
-        await this.sleep(500);
-        
-        // Menu options with links
-        await this.createMenuOption('GITHUB', 'https://github.com/typedcypher');
-        await this.createMenuOption('X', 'https://x.com/typedcypher');
-        await this.createMenuOption('NOSTR', 'https://njump.me/typedcypher.com');
-        
-        await this.addLine('', '', false);
-        await this.sleep(500);
-        await this.addLine('SYSTEM READY_', '', true);
-        
-        // Add interactive effects after boot
+
+        this.showSetupMenu();
+        this.addKeyboardNavigation();
         this.addInteractiveEffects();
     }
 
-    async createMenuOption(text, link) {
-        const option = document.createElement('div');
-        option.className = 'menu-option terminal-line';
-        
-        const anchor = document.createElement('a');
-        anchor.href = link;
-        anchor.target = '_blank';
-        anchor.rel = 'noopener noreferrer';
-        
-        this.output.appendChild(option);
-        option.appendChild(anchor);
-        
-        // Trigger reflow for animation
-        option.offsetHeight;
-        
-        await this.typeText(text, anchor, 30);
-        
-        // Move cursor after option
-        this.output.appendChild(this.cursor);
-        
-        await this.sleep(300);
+    showSetupMenu() {
+        const content = document.querySelector('.terminal-content');
+        content.innerHTML = '';
+
+        // Box container
+        const box = document.createElement('div');
+        box.className = 'setup-box';
+        content.appendChild(box);
+
+        // Title
+        const title = document.createElement('div');
+        title.className = 'setup-title';
+        title.textContent = 'T Y P E D C Y P H E R';
+        box.appendChild(title);
+
+        // Tab bar
+        const tabBar = document.createElement('div');
+        tabBar.className = 'setup-tab-bar';
+        this.tabs.forEach((tab, index) => {
+            const tabEl = document.createElement('div');
+            tabEl.className = 'setup-tab';
+            if (index === this.activeTab) tabEl.classList.add('setup-tab-active');
+            tabEl.textContent = tab.label;
+            tabEl.addEventListener('mouseenter', () => {
+                this.activeTab = index;
+                this.activeItem = 0;
+                this.renderMenu();
+            });
+            tabEl.addEventListener('click', () => {
+                this.activeTab = index;
+                this.activeItem = 0;
+                this.renderMenu();
+            });
+            tabBar.appendChild(tabEl);
+        });
+        box.appendChild(tabBar);
+
+        // Separator
+        const sep = document.createElement('div');
+        sep.className = 'setup-separator';
+        box.appendChild(sep);
+
+        // Content area
+        const contentArea = document.createElement('div');
+        contentArea.className = 'setup-content';
+        contentArea.id = 'setup-content';
+        box.appendChild(contentArea);
+
+        // Status bar
+        const statusBar = document.createElement('div');
+        statusBar.className = 'setup-status-bar';
+        statusBar.textContent = 'h/l:Tab   j/k:Move   Enter:Open';
+        content.appendChild(statusBar);
+
+        this.menuReady = true;
+        this.renderMenu();
     }
 
-    createBurnInLayers() {
-        // Add data-text attribute to header for CSS burn-in effect
-        const header = document.querySelector('.terminal-header');
-        if (header) {
-            header.setAttribute('data-text', header.textContent);
-        }
-
-        // Create persistent burn-in traces container
-        const burnContainer = document.createElement('div');
-        burnContainer.className = 'menu-burn';
-        document.querySelector('.terminal-content').appendChild(burnContainer);
-        
-        // Store reference for later use
-        this.burnContainer = burnContainer;
-    }
-
-    createBurnInText(text, x, y, permanent = false) {
-        const burnElement = document.createElement('div');
-        burnElement.textContent = text;
-        burnElement.className = permanent ? 'burn-in-permanent' : 'burn-in';
-        burnElement.style.left = x + 'px';
-        burnElement.style.top = y + 'px';
-        
-        if (this.burnContainer) {
-            this.burnContainer.appendChild(burnElement);
-        }
-        
-        // Remove temporary burn-in after animation completes
-        if (!permanent) {
-            setTimeout(() => {
-                if (burnElement.parentNode) {
-                    burnElement.remove();
-                }
-            }, 120000); // 2 minutes
-        }
-    }
-
-    async addLine(text, className = '', typeEffect = true) {
-        const line = document.createElement('div');
-        line.className = `terminal-line ${className}`;
-        this.output.appendChild(line);
-        
-        // Get position for burn-in effect
-        const rect = line.getBoundingClientRect();
-        const parentRect = this.output.getBoundingClientRect();
-        const relativeY = rect.top - parentRect.top;
-        
-        // Trigger reflow to ensure animation plays
-        line.offsetHeight;
-        
-        if (typeEffect) {
-            await this.typeText(text, line);
-            // Create burn-in for typed text
-            if (text && Math.random() < 0.3) { // 30% chance for burn-in
-                this.createBurnInText(text, 0, relativeY, false);
-            }
-        } else {
-            line.textContent = text;
-            line.style.opacity = '1';
-        }
-        
-        // Move cursor to end
-        this.output.appendChild(this.cursor);
-        
-        await this.sleep(this.lineDelay);
-    }
-
-    async createMenuOption(text, link) {
-        const option = document.createElement('div');
-        option.className = 'menu-option terminal-line';
-        
-        const anchor = document.createElement('a');
-        anchor.href = link;
-        anchor.target = '_blank';
-        anchor.rel = 'noopener noreferrer';
-        
-        this.output.appendChild(option);
-        option.appendChild(anchor);
-        
-        // Get position for permanent burn-in
-        const rect = option.getBoundingClientRect();
-        const parentRect = this.output.getBoundingClientRect();
-        const relativeY = rect.top - parentRect.top;
-        
-        // Trigger reflow for animation
-        option.offsetHeight;
-        
-        await this.typeText(text, anchor, 30);
-        
-        // Create permanent burn-in for menu items
-        this.createBurnInText('> ' + text, 0, relativeY, true);
-
-        // Track menu option for keyboard navigation
-        const menuIndex = this.menuOptions.length;
-        this.menuOptions.push(option);
-
-        option.addEventListener('mouseenter', () => {
-            this.selectMenuOption(menuIndex);
+    renderMenu() {
+        // Update tabs
+        const tabEls = document.querySelectorAll('.setup-tab');
+        tabEls.forEach((el, i) => {
+            el.classList.toggle('setup-tab-active', i === this.activeTab);
         });
 
-        // Move cursor after option
-        this.output.appendChild(this.cursor);
+        // Update content
+        const contentArea = document.getElementById('setup-content');
+        if (!contentArea) return;
+        contentArea.innerHTML = '';
 
-        await this.sleep(300);
+        const currentTab = this.tabs[this.activeTab];
+        if (!currentTab) return;
+
+        currentTab.items.forEach((item, index) => {
+            const row = document.createElement('div');
+            row.className = 'setup-item';
+            if (index === this.activeItem) row.classList.add('setup-item-active');
+            if (item.link) row.classList.add('setup-item-link');
+            row.textContent = item.label;
+
+            row.addEventListener('mouseenter', () => {
+                if (this.activeItem === index) return;
+                this.activeItem = index;
+                this.updateItemHighlight();
+            });
+
+            row.addEventListener('click', () => {
+                if (item.link) {
+                    window.open(item.link, '_blank', 'noopener,noreferrer');
+                }
+            });
+
+            contentArea.appendChild(row);
+        });
     }
 
-    selectMenuOption(index) {
-        if (this.menuOptions.length === 0) return;
-
-        this.menuOptions.forEach(opt => opt.classList.remove('menu-option-selected'));
-
-        this.selectedIndex = ((index % this.menuOptions.length) + this.menuOptions.length) % this.menuOptions.length;
-        this.menuOptions[this.selectedIndex].classList.add('menu-option-selected');
+    updateItemHighlight() {
+        const items = document.querySelectorAll('.setup-item');
+        items.forEach((el, i) => {
+            el.classList.toggle('setup-item-active', i === this.activeItem);
+        });
     }
 
-    openSelectedMenuOption() {
-        if (this.selectedIndex < 0 || this.selectedIndex >= this.menuOptions.length) return;
+    addKeyboardNavigation() {
+        document.addEventListener('keydown', (e) => {
+            if (!this.menuReady) return;
 
-        const anchor = this.menuOptions[this.selectedIndex].querySelector('a');
-        if (anchor) {
-            window.open(anchor.href, '_blank', 'noopener,noreferrer');
-        }
+            const currentTab = this.tabs[this.activeTab];
+
+            if (e.key === 'l' || e.key === 'ArrowRight') {
+                e.preventDefault();
+                this.activeTab = (this.activeTab + 1) % this.tabs.length;
+                this.activeItem = 0;
+                this.renderMenu();
+            } else if (e.key === 'h' || e.key === 'ArrowLeft') {
+                e.preventDefault();
+                this.activeTab = (this.activeTab - 1 + this.tabs.length) % this.tabs.length;
+                this.activeItem = 0;
+                this.renderMenu();
+            } else if (e.key === 'j' || e.key === 'ArrowDown') {
+                e.preventDefault();
+                this.activeItem = (this.activeItem + 1) % currentTab.items.length;
+                this.renderMenu();
+            } else if (e.key === 'k' || e.key === 'ArrowUp') {
+                e.preventDefault();
+                this.activeItem = (this.activeItem - 1 + currentTab.items.length) % currentTab.items.length;
+                this.renderMenu();
+            } else if (e.key === 'Enter') {
+                e.preventDefault();
+                const item = currentTab.items[this.activeItem];
+                if (item && item.link) {
+                    window.open(item.link, '_blank', 'noopener,noreferrer');
+                }
+            }
+        });
     }
 
     addInteractiveEffects() {
-        // Vi-style keyboard navigation
-        document.addEventListener('keydown', (e) => {
-            if (this.menuOptions.length === 0) return;
-
-            if (e.key === 'j' || e.key === 'ArrowDown') {
-                e.preventDefault();
-                this.selectMenuOption(this.selectedIndex + 1);
-            } else if (e.key === 'k' || e.key === 'ArrowUp') {
-                e.preventDefault();
-                this.selectMenuOption(this.selectedIndex - 1);
-            } else if (e.key === 'Enter') {
-                e.preventDefault();
-                this.openSelectedMenuOption();
-            }
-        });
         const screen = document.querySelector('.terminal-screen');
         const container = document.querySelector('.terminal-container');
-        
+
         // Random glitch effect
         setInterval(() => {
             if (Math.random() < 0.02) {
                 screen.style.transform = `translateX(${Math.random() * 2 - 1}px)`;
-                
                 setTimeout(() => {
                     screen.style.transform = 'translateX(0)';
                 }, 50);
@@ -284,86 +263,64 @@ class AlienTerminal {
 
         // Occasional intense flicker
         setInterval(() => {
-            if (Math.random() < 0.004) { // 0.4% chance (reduced)
+            if (Math.random() < 0.004) {
                 container.style.animation = 'intense-flicker 0.8s';
                 setTimeout(() => {
                     container.style.animation = 'flicker 15s infinite';
                 }, 800);
             }
-        }, 10000); // Check every 10 seconds instead of 4
-        
+        }, 10000);
+
         // Random micro-flickers
         setInterval(() => {
-            if (Math.random() < 0.015) { // 1.5% chance (reduced)
-                const duration = 100 + Math.random() * 200; // Longer duration
+            if (Math.random() < 0.015) {
+                const duration = 100 + Math.random() * 200;
                 screen.classList.add('random-flicker');
                 setTimeout(() => {
                     screen.classList.remove('random-flicker');
                 }, duration);
             }
-        }, 3000); // Check every 3 seconds instead of 1
-        
+        }, 3000);
+
         // Brightness variation
         setInterval(() => {
-            if (Math.random() < 0.008) { // 0.8% chance (reduced)
-                const brightness = 0.85 + Math.random() * 0.3; // 0.85 to 1.15 (less extreme)
-                const contrast = 0.95 + Math.random() * 0.15; // 0.95 to 1.1 (less extreme)
+            if (Math.random() < 0.008) {
+                const brightness = 0.85 + Math.random() * 0.3;
+                const contrast = 0.95 + Math.random() * 0.15;
                 screen.style.filter = `brightness(${brightness}) contrast(${contrast})`;
                 setTimeout(() => {
                     screen.style.filter = '';
-                }, 200 + Math.random() * 300); // Longer duration
+                }, 200 + Math.random() * 300);
             }
-        }, 6000); // Check every 6 seconds instead of 2.5
+        }, 6000);
 
-        // Phosphor burn-in effect simulation
-        const burnIn = document.createElement('div');
-        burnIn.style.cssText = `
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: radial-gradient(
-                ellipse at center,
-                transparent 0%,
-                transparent 40%,
-                rgba(12, 204, 104, 0.01) 70%,
-                transparent 100%
-            );
-            pointer-events: none;
-            z-index: 1;
-        `;
-        document.querySelector('.terminal-screen').appendChild(burnIn);
-        
         // Add ghost overlay
         const ghostOverlay = document.createElement('div');
         ghostOverlay.className = 'ghost-overlay';
-        document.querySelector('.terminal-screen').appendChild(ghostOverlay);
+        screen.appendChild(ghostOverlay);
     }
 }
 
 // Initialize terminal on page load
 document.addEventListener('DOMContentLoaded', () => {
     new AlienTerminal();
-    
-    // Add startup sound effect simulation (visual feedback)
+
     const body = document.body;
     body.style.filter = 'brightness(0)';
-    
+
     setTimeout(() => {
         body.style.transition = 'filter 2s ease-out';
         body.style.filter = 'brightness(1)';
     }, 100);
-    
-    // Create glow lines
+
     const screen = document.querySelector('.terminal-screen');
-    
+
     // Horizontal glow line
     const glowLineH = document.createElement('div');
     glowLineH.className = 'glow-line-horizontal';
     screen.appendChild(glowLineH);
-    
-    // Interference bands (multiple)
+
+    // Interference bands
     setTimeout(() => {
         for (let i = 0; i < 3; i++) {
             const band = document.createElement('div');
@@ -374,8 +331,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }, 3000);
 });
 
-// Keyboard sound effect simulation (visual feedback on keypress)
-document.addEventListener('keydown', (e) => {
+// Keyboard sound effect simulation
+document.addEventListener('keydown', () => {
     const screen = document.querySelector('.terminal-screen');
     if (screen) {
         screen.style.filter = 'brightness(1.05)';

--- a/styles.css
+++ b/styles.css
@@ -260,7 +260,7 @@ body::before {
     word-wrap: break-word;
     text-align: center;
     width: 100%;
-    max-width: 600px;
+    max-width: 800px;
 }
 
 .terminal-line {
@@ -276,7 +276,7 @@ body::before {
 /* Setup menu layout */
 .setup-box {
     width: 100%;
-    max-width: 600px;
+    max-width: 800px;
     border: 3px solid #0ccc68;
     padding: 15px 20px 20px;
     box-shadow:
@@ -300,7 +300,7 @@ body::before {
     gap: 10px;
     margin-bottom: 0;
     width: 100%;
-    max-width: 600px;
+    max-width: 800px;
 }
 
 .setup-tab {
@@ -320,7 +320,7 @@ body::before {
 
 .setup-separator {
     width: 100%;
-    max-width: 600px;
+    max-width: 800px;
     height: 1px;
     background: #0a5530;
     margin: 10px 0 20px;
@@ -329,7 +329,7 @@ body::before {
 
 .setup-content {
     width: 100%;
-    max-width: 600px;
+    max-width: 800px;
     min-height: 200px;
     text-align: left;
     padding: 0 10px;

--- a/styles.css
+++ b/styles.css
@@ -16,42 +16,25 @@ body {
     position: relative;
 }
 
-/* CRT curved screen effect */
+/* CRT edge glow */
 body::before {
     content: "";
-    position: fixed;
-    top: -20%;
-    left: -10%;
-    width: 120%;
-    height: 140%;
-    background: radial-gradient(
-        ellipse at center,
-        transparent 0%,
-        transparent 65%,
-        rgba(0, 0, 0, 0.4) 75%,
-        rgba(0, 0, 0, 0.8) 85%,
-        rgba(0, 0, 0, 1) 100%
-    );
-    pointer-events: none;
-    z-index: 100;
-}
-
-/* Screen edge vignette */
-.crt-overlay {
     position: fixed;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
-    background: radial-gradient(
-        ellipse at center,
-        transparent 0%,
-        transparent 50%,
-        rgba(0, 0, 0, 0.3) 70%,
-        rgba(0, 0, 0, 0.9) 100%
-    );
+    box-shadow:
+        inset 0 0 80px rgba(12, 204, 104, 0.6),
+        inset 0 0 150px rgba(12, 204, 104, 0.3),
+        inset 0 0 300px rgba(12, 204, 104, 0.1);
     pointer-events: none;
-    z-index: 99;
+    z-index: 100;
+}
+
+/* Screen edge vignette - disabled for full-screen glow */
+.crt-overlay {
+    display: none;
 }
 
 /* Scanlines */
@@ -204,9 +187,8 @@ body::before {
 
 /* Terminal container */
 .terminal-container {
-    width: 90%;
-    max-width: 900px;
-    height: 600px;
+    width: 100%;
+    height: 100vh;
     position: relative;
     z-index: 2;
     filter: brightness(1.2) contrast(1.1);
@@ -217,13 +199,12 @@ body::before {
     width: 100%;
     height: 100%;
     background: #000;
-    border: 2px solid #0a5530;
-    border-radius: 5px;
-    padding: 30px;
-    box-shadow: 
-        0 0 100px rgba(12, 204, 104, 0.5),
-        inset 0 0 50px rgba(12, 204, 104, 0.1),
-        0 0 20px rgba(12, 204, 104, 0.8);
+    border: none;
+    border-radius: 0;
+    padding: 40px 60px;
+    box-shadow:
+        inset 0 0 80px rgba(12, 204, 104, 0.15),
+        inset 0 0 200px rgba(12, 204, 104, 0.05);
     position: relative;
     overflow: hidden;
 }
@@ -244,41 +225,6 @@ body::before {
     pointer-events: none;
 }
 
-/* Terminal header */
-.terminal-header {
-    color: #0ccc68;
-    font-size: 12px;
-    margin-bottom: 20px;
-    padding-bottom: 10px;
-    border-bottom: 1px solid #0a5530;
-    letter-spacing: 2px;
-    text-shadow: 
-        0.8px 0 0 rgba(255, 0, 0, 0.25),
-        -0.8px 0 0 rgba(0, 255, 255, 0.25),
-        0 0 10px rgba(12, 204, 104, 0.8),
-        0 0 3px rgba(12, 204, 104, 0.4);
-    animation: text-glow 2s ease-in-out infinite;
-    transform: scaleY(0.95) scaleX(1.03);
-    filter: blur(0.4px) contrast(1.2);
-    -webkit-font-smoothing: none;
-}
-
-@keyframes text-glow {
-    0%, 100% { 
-        text-shadow: 
-            0.8px 0 0 rgba(255, 0, 0, 0.25),
-            -0.8px 0 0 rgba(0, 255, 255, 0.25),
-            0 0 10px rgba(12, 204, 104, 0.8),
-            0 0 3px rgba(12, 204, 104, 0.4);
-    }
-    50% { 
-        text-shadow: 
-            1px 0 0 rgba(255, 0, 0, 0.3),
-            -1px 0 0 rgba(0, 255, 255, 0.3),
-            0 0 15px rgba(12, 204, 104, 1),
-            0 0 5px rgba(12, 204, 104, 0.5);
-    }
-}
 
 /* Terminal content */
 .terminal-content {
@@ -290,7 +236,10 @@ body::before {
     overflow-y: auto;
     overflow-x: hidden;
     font-weight: 500;
-    text-shadow: 
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-shadow:
         0.5px 0 0 rgba(255, 0, 0, 0.3),
         -0.5px 0 0 rgba(0, 255, 255, 0.3),
         0 0 2px rgba(12, 204, 104, 0.4),
@@ -309,6 +258,9 @@ body::before {
 #terminal-output {
     white-space: pre-wrap;
     word-wrap: break-word;
+    text-align: center;
+    width: 100%;
+    max-width: 600px;
 }
 
 .terminal-line {
@@ -321,58 +273,99 @@ body::before {
     to { opacity: 1; }
 }
 
-/* Typing animation */
-.typing {
-    overflow: hidden;
-    white-space: nowrap;
-    margin: 5px 0;
-    letter-spacing: 1px;
+/* Setup menu layout */
+.setup-box {
+    width: 100%;
+    max-width: 600px;
+    border: 3px solid #0ccc68;
+    padding: 15px 20px 20px;
+    box-shadow:
+        0 0 8px rgba(12, 204, 104, 0.3),
+        inset 0 0 8px rgba(12, 204, 104, 0.05);
 }
 
-/* Menu options */
-.menu-option {
-    margin: 15px 0;
-    padding-left: 20px;
-    transition: all 0.3s;
+.setup-title {
+    font-size: 18px;
+    letter-spacing: 6px;
+    margin: 10px 0 20px;
+    text-align: center;
+    text-shadow:
+        0 0 10px rgba(12, 204, 104, 0.8),
+        0 0 3px rgba(12, 204, 104, 0.4);
+}
+
+.setup-tab-bar {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    margin-bottom: 0;
+    width: 100%;
+    max-width: 600px;
+}
+
+.setup-tab {
+    padding: 6px 20px;
     cursor: pointer;
-    position: relative;
-    transform: scaleY(0.98);
-    filter: blur(0.2px);
+    letter-spacing: 2px;
+    font-size: 14px;
+    transition: all 0.15s;
+    white-space: nowrap;
 }
 
-.menu-option::before {
-    content: ">";
-    position: absolute;
-    left: 0;
-    color: #0ccc68;
-    text-shadow: 
-        0.5px 0 0 rgba(255, 0, 0, 0.2),
-        -0.5px 0 0 rgba(0, 255, 255, 0.2);
-}
-
-.menu-option-selected {
-    color: #0a0a0a;
+.setup-tab-active {
     background: #0ccc68;
-    padding-left: 30px;
-    text-shadow: none;
-    filter: none;
-}
-
-.menu-option-selected a,
-.menu-option-selected a .char,
-.menu-option-selected .char {
-    color: #0a0a0a !important;
-    text-shadow: none !important;
-    animation: none !important;
-    opacity: 1 !important;
-    filter: none !important;
-}
-
-.menu-option-selected::before {
-    content: ">>";
     color: #0a0a0a;
     text-shadow: none;
-    animation: none;
+}
+
+.setup-separator {
+    width: 100%;
+    max-width: 600px;
+    height: 1px;
+    background: #0a5530;
+    margin: 10px 0 20px;
+    box-shadow: 0 0 4px rgba(12, 204, 104, 0.3);
+}
+
+.setup-content {
+    width: 100%;
+    max-width: 600px;
+    min-height: 200px;
+    text-align: left;
+    padding: 0 10px;
+}
+
+.setup-item {
+    padding: 8px 16px;
+    cursor: default;
+    letter-spacing: 1px;
+    font-size: 15px;
+    transition: all 0.1s;
+    margin: 4px 0;
+}
+
+.setup-item-link {
+    cursor: pointer;
+}
+
+.setup-item-active {
+    background: #0ccc68;
+    color: #0a0a0a;
+    text-shadow: none;
+}
+
+.setup-status-bar {
+    position: absolute;
+    bottom: 10px;
+    left: 0;
+    width: 100%;
+    text-align: center;
+    font-size: 12px;
+    letter-spacing: 3px;
+    color: #0a8850;
+    border-top: 1px solid #0a5530;
+    padding-top: 10px;
+    margin-top: auto;
 }
 
 /* Blinking cursor */
@@ -587,46 +580,6 @@ body::before {
     animation: boot-flash 2s ease-out;
 }
 
-/* Burn-in effect classes */
-.burn-in {
-    position: absolute;
-    color: #0ccc68;
-    opacity: 0.15;
-    filter: blur(0.8px);
-    text-shadow: 
-        0 0 20px rgba(12, 204, 104, 0.3),
-        0 0 40px rgba(12, 204, 104, 0.2);
-    pointer-events: none;
-    z-index: -1;
-    animation: burn-fade 120s ease-out forwards;
-}
-
-@keyframes burn-fade {
-    0% { 
-        opacity: 0.15;
-        filter: blur(0.8px);
-    }
-    50% {
-        opacity: 0.08;
-        filter: blur(1.2px);
-    }
-    100% { 
-        opacity: 0.03;
-        filter: blur(2px);
-    }
-}
-
-.burn-in-permanent {
-    position: absolute;
-    color: #0a8850;
-    opacity: 0.06;
-    filter: blur(1px) contrast(0.8);
-    text-shadow: 0 0 15px rgba(12, 204, 104, 0.2);
-    pointer-events: none;
-    z-index: -2;
-    transform: translate(1px, 1px);
-}
-
 /* Ghost image overlay for persistent elements */
 .ghost-overlay {
     position: absolute;
@@ -637,80 +590,13 @@ body::before {
     pointer-events: none;
     opacity: 0.04;
     filter: blur(1.5px);
-    background: 
-        linear-gradient(180deg, 
-            transparent 0%, 
+    background:
+        linear-gradient(180deg,
+            transparent 0%,
             rgba(12, 204, 104, 0.02) 30%,
             rgba(12, 204, 104, 0.01) 70%,
             transparent 100%);
     mix-blend-mode: screen;
-}
-
-/* Header burn-in specific */
-.terminal-header {
-    position: relative;
-}
-
-.terminal-header::after {
-    content: attr(data-text);
-    position: absolute;
-    top: 2px;
-    left: 2px;
-    color: #0a8850;
-    opacity: 0.08;
-    filter: blur(1.2px);
-    text-shadow: 0 0 20px rgba(12, 204, 104, 0.15);
-    z-index: -1;
-    animation: header-burn 60s ease-in-out infinite;
-}
-
-@keyframes header-burn {
-    0%, 100% {
-        opacity: 0.08;
-        transform: translate(2px, 2px);
-    }
-    25% {
-        opacity: 0.06;
-        transform: translate(1px, 3px);
-    }
-    50% {
-        opacity: 0.07;
-        transform: translate(3px, 1px);
-    }
-    75% {
-        opacity: 0.05;
-        transform: translate(1px, 2px);
-    }
-}
-
-/* Menu burn-in traces */
-.menu-burn {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    pointer-events: none;
-}
-
-.menu-burn-item {
-    position: absolute;
-    color: #0a8850;
-    opacity: 0.05;
-    filter: blur(1.5px);
-    text-shadow: 0 0 25px rgba(12, 204, 104, 0.1);
-    animation: menu-ghost 180s ease-out forwards;
-}
-
-@keyframes menu-ghost {
-    0% {
-        opacity: 0.05;
-        filter: blur(1.5px);
-    }
-    100% {
-        opacity: 0.02;
-        filter: blur(3px);
-    }
 }
 
 /* Link styling */
@@ -721,21 +607,27 @@ a {
 
 /* Responsive design */
 @media (max-width: 768px) {
-    .terminal-container {
-        width: 95%;
-        height: 80vh;
-    }
-    
     .terminal-screen {
         padding: 20px;
     }
-    
+
     .terminal-content {
         font-size: 14px;
     }
-    
-    .terminal-header {
-        font-size: 10px;
+
+    .setup-title {
+        font-size: 14px;
+        letter-spacing: 4px;
+        margin: 20px 0 20px;
+    }
+
+    .setup-tab {
+        padding: 5px 12px;
+        font-size: 12px;
+    }
+
+    .setup-item {
+        font-size: 13px;
     }
 }
 
@@ -744,8 +636,23 @@ a {
         font-size: 12px;
         line-height: 1.6;
     }
-    
+
     .terminal-screen {
         padding: 15px;
+    }
+
+    .setup-tab-bar {
+        gap: 4px;
+    }
+
+    .setup-tab {
+        padding: 4px 8px;
+        font-size: 11px;
+        letter-spacing: 1px;
+    }
+
+    .setup-title {
+        font-size: 12px;
+        letter-spacing: 3px;
     }
 }


### PR DESCRIPTION
## Summary
- Redesign layout from vertical link list to IBM 3151-inspired setup menu with horizontal tabs and bordered content box
- Three tabs: GENERAL (system info), INTERFACES (GitHub, X, Nostr links), PROJECTS (pinned repos)
- Full-screen terminal with green edge glow, vi-style navigation (h/l for tabs, j/k for items, Enter to open), and mouse support
- Add favicon from logo, update Nostr link to njump.me

## Test plan
- [ ] Boot sequence plays then transitions to setup menu
- [ ] h/l and arrow keys switch between tabs
- [ ] j/k and arrow keys navigate items within a tab
- [ ] Enter opens link items in new tab
- [ ] Mouse hover highlights tabs and items
- [ ] Mouse click opens link items in new tab
- [ ] CRT effects (scanlines, flicker, glow) still work
- [ ] Responsive layout on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)