### PR TITLE
Fix relay health check CORS error

### DIFF
--- a/script.js
+++ b/script.js
@@ -185,10 +185,8 @@ class AlienTerminal {
 
     async fetchRelayStatus() {
         try {
-            const response = await fetch('https://relay.typedcypher.com/health');
-            const text = (await response.text()).trim();
-            const status = text === 'OK' ? 'ONLINE' : 'OFFLINE';
-            this.updateGeneralItem('relay-status', `Relay: ${status}`);
+            await fetch('https://relay.typedcypher.com/health', { mode: 'no-cors' });
+            this.updateGeneralItem('relay-status', 'Relay: ONLINE');
         } catch {
             this.updateGeneralItem('relay-status', 'Relay: OFFLINE');
         }


### PR DESCRIPTION
## Summary
- Fix CORS error when fetching relay health status from `relay.typedcypher.com/health`
- Use `mode: 'no-cors'` to check reachability without reading the response body
- If the server is reachable, shows ONLINE; if unreachable, shows OFFLINE

## Test plan
- [ ] Verify relay status shows ONLINE when relay is up
- [ ] Verify no CORS errors in browser console
- [ ] Disable network and confirm OFFLINE fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)